### PR TITLE
Adds support to get multiple frames for a thumbnail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ tempfile = "^3.10.1"
 image = { version = "^0.25.0", default-features = false, features=["jpeg", "png"]}
 lazy_static = "^1.4.0"
 file-format = { version = "^0.25.0", features = ["reader"] }
+
+[features]
+default = ["webp"]
+webp = ["image/webp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/Trivernis/thumbnailer"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webp = "0.3.0"
-mime = "0.3.17"
-rayon = "1.10.0"
-tempfile = "3.10.1"
+webp = "^0.3.0"
+rayon = "^1.10.0"
+tempfile = "^3.10.1"
 image = { version = "^0.25.0", default-features = false, features=["jpeg", "png"]}
-lazy_static = "1.4.0"
+lazy_static = "^1.4.0"
+file-format = { version = "^0.25.0", features = ["reader"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Trivernis/thumbnailer"
 webp = "^0.3.0"
 rayon = "^1.10.0"
 tempfile = "^3.10.1"
-image = { version = "^0.25.0", default-features = false, features=["jpeg", "png"]}
+image = { version = "^0.25.2", default-features = false, features=["jpeg", "png", "gif"]}
 lazy_static = "^1.4.0"
 file-format = { version = "^0.25.0", features = ["reader"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/Trivernis/thumbnailer"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webp = "0.2.7"
+webp = "0.3.0"
 mime = "0.3.17"
 rayon = "1.10.0"
 tempfile = "3.10.1"
-image= "0.25.1"
+image = { version = "^0.25.0", default-features = false, features=["jpeg"]}
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ webp = "0.3.0"
 mime = "0.3.17"
 rayon = "1.10.0"
 tempfile = "3.10.1"
-image = { version = "^0.25.0", default-features = false, features=["jpeg"]}
+image = { version = "^0.25.0", default-features = false, features=["jpeg", "png"]}
 lazy_static = "1.4.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
+use file_format::FileFormat;
 use image::ImageError;
-use mime::Mime;
 use std::fmt::{Debug, Display, Formatter};
 use std::io;
 
@@ -8,15 +8,10 @@ pub type ThumbResult<T> = Result<T, ThumbError>;
 #[derive(Debug)]
 pub enum ThumbError {
     IO(io::Error),
-
     Image(image::error::ImageError),
-
     Decode,
-
-    Unsupported(Mime),
-
+    Unsupported(FileFormat),
     NullVideo,
-
     FFMPEG(String),
 }
 

--- a/src/formats/image_format.rs
+++ b/src/formats/image_format.rs
@@ -1,11 +1,9 @@
 use crate::error::{ThumbError, ThumbResult};
-use file_format::{FileFormat, Kind};
+use file_format::FileFormat;
 use image::io::Reader as ImageReader;
 use image::{DynamicImage, ImageFormat};
 use std::io::{BufRead, Read, Seek};
 use webp::Decoder as WebpDecoder;
-
-const IMAGE_WEBP_MIME: &str = "image/webp";
 
 /// Reads an image with a known mime type
 pub fn read_image<R: BufRead + Seek>(reader: R, format: FileFormat) -> ThumbResult<DynamicImage> {

--- a/src/formats/image_format.rs
+++ b/src/formats/image_format.rs
@@ -1,18 +1,22 @@
 use crate::error::{ThumbError, ThumbResult};
+use file_format::{FileFormat, Kind};
 use image::io::Reader as ImageReader;
 use image::{DynamicImage, ImageFormat};
-use mime::Mime;
 use std::io::{BufRead, Read, Seek};
 use webp::Decoder as WebpDecoder;
 
 const IMAGE_WEBP_MIME: &str = "image/webp";
 
 /// Reads an image with a known mime type
-pub fn read_image<R: BufRead + Seek>(reader: R, mime: Mime) -> ThumbResult<DynamicImage> {
-    match mime.essence_str() {
+pub fn read_image<R: BufRead + Seek>(reader: R, format: FileFormat) -> ThumbResult<DynamicImage> {
+    match format {
+        FileFormat::Webp => read_webp_image(reader),
+        _ => read_generic_image(reader, mime_to_image_format(format)),
+    }
+    /* match mime.essence_str() {
         IMAGE_WEBP_MIME => read_webp_image(reader),
         _ => read_generic_image(reader, mime_to_image_format(mime)),
-    }
+    }*/
 }
 
 /// Reads a webp image
@@ -42,12 +46,12 @@ fn read_generic_image<R: BufRead + Seek>(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn mime_to_image_format(mime: Mime) -> Option<ImageFormat> {
-    match mime.subtype().as_str() {
-        "png" => Some(ImageFormat::Png),
-        "jpeg" => Some(ImageFormat::Jpeg),
-        "bmp" => Some(ImageFormat::Bmp),
-        "gif" => Some(ImageFormat::Gif),
+fn mime_to_image_format(mime: FileFormat) -> Option<ImageFormat> {
+    match mime {
+        FileFormat::PortableNetworkGraphics => Some(ImageFormat::Png),
+        FileFormat::JointPhotographicExpertsGroup => Some(ImageFormat::Jpeg),
+        FileFormat::WindowsBitmap => Some(ImageFormat::Bmp),
+        FileFormat::GraphicsInterchangeFormat => Some(ImageFormat::Gif),
         _ => None,
     }
 }

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -14,6 +14,10 @@ pub fn get_base_image<R: BufRead + Seek>(reader: R, mime: FileFormat) -> ThumbRe
     match mime.kind() {
         Kind::Image => read_image(reader, mime),
         Kind::Video => get_video_frame(reader, mime),
+        Kind::Other => match mime {
+            FileFormat::Mpeg4Part14 => get_video_frame(reader, mime),
+            _ => Err(ThumbError::Unsupported(mime)),
+        },
         _ => Err(ThumbError::Unsupported(mime)),
     }
 }

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,7 +1,7 @@
 use crate::error::{ThumbError, ThumbResult};
 use crate::formats::image_format::read_image;
+use file_format::{FileFormat, Kind};
 use image::DynamicImage;
-use mime::Mime;
 use std::io::{BufRead, Seek};
 
 use crate::formats::video_format::get_video_frame;
@@ -10,10 +10,10 @@ pub mod image_format;
 pub mod video_format;
 
 /// Reads the buffer content into an image that can be used for thumbnail generation
-pub fn get_base_image<R: BufRead + Seek>(reader: R, mime: Mime) -> ThumbResult<DynamicImage> {
-    match mime.type_() {
-        mime::IMAGE => read_image(reader, mime),
-        mime::VIDEO => get_video_frame(reader, mime),
+pub fn get_base_image<R: BufRead + Seek>(reader: R, mime: FileFormat) -> ThumbResult<DynamicImage> {
+    match mime.kind() {
+        Kind::Image => read_image(reader, mime),
+        Kind::Video => get_video_frame(reader, mime),
         _ => Err(ThumbError::Unsupported(mime)),
     }
 }

--- a/src/formats/video_format.rs
+++ b/src/formats/video_format.rs
@@ -13,7 +13,6 @@ pub fn get_video_frame<R: BufRead + Seek>(
     mime: FileFormat,
 ) -> ThumbResult<DynamicImage> {
     lazy_static::lazy_static! { static ref FFMPEG_INSTALLED: bool = is_ffmpeg_installed(); }
-
     if !*FFMPEG_INSTALLED {
         return Err(ThumbError::Unsupported(mime));
     }

--- a/src/formats/video_format.rs
+++ b/src/formats/video_format.rs
@@ -1,10 +1,11 @@
-use crate::error::{ThumbError, ThumbResult};
+use crate::error::{self, ThumbError, ThumbResult};
 use crate::utils::ffmpeg_cli::{get_png_frame, is_ffmpeg_installed};
 use file_format::FileFormat;
 use image::io::Reader as ImageReader;
 use image::{DynamicImage, ImageFormat};
+use std::error::Error;
 use std::fs;
-use std::io::{BufRead, Cursor, Seek};
+use std::io::{BufRead, Cursor, ErrorKind, Seek};
 use std::path::PathBuf;
 
 pub fn get_video_frame<R: BufRead + Seek>(

--- a/src/formats/video_format.rs
+++ b/src/formats/video_format.rs
@@ -1,13 +1,16 @@
 use crate::error::{ThumbError, ThumbResult};
 use crate::utils::ffmpeg_cli::{get_png_frame, is_ffmpeg_installed};
+use file_format::FileFormat;
 use image::io::Reader as ImageReader;
 use image::{DynamicImage, ImageFormat};
-use mime::Mime;
 use std::fs;
 use std::io::{BufRead, Cursor, Seek};
 use std::path::PathBuf;
 
-pub fn get_video_frame<R: BufRead + Seek>(mut reader: R, mime: Mime) -> ThumbResult<DynamicImage> {
+pub fn get_video_frame<R: BufRead + Seek>(
+    mut reader: R,
+    mime: FileFormat,
+) -> ThumbResult<DynamicImage> {
     lazy_static::lazy_static! { static ref FFMPEG_INSTALLED: bool = is_ffmpeg_installed(); }
 
     if !*FFMPEG_INSTALLED {
@@ -17,7 +20,7 @@ pub fn get_video_frame<R: BufRead + Seek>(mut reader: R, mime: Mime) -> ThumbRes
     let tempdir = tempfile::tempdir()?;
     let path = PathBuf::from(tempdir.path())
         .join("video")
-        .with_extension(mime.subtype().as_str());
+        .with_extension(mime.extension());
 
     let mut buf = Vec::new();
     reader.read_to_end(&mut buf)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub(crate) mod utils;
 #[derive(Clone, Debug)]
 pub struct Thumbnail {
     inner: DynamicImage,
+    mime: FileFormat,
 }
 
 #[derive(Clone, Debug)]
@@ -90,6 +91,11 @@ impl Thumbnail {
         Ok(())
     }
 
+    /// Returns the fileformat that it's parsed
+    pub fn return_fileformat(&self) -> FileFormat {
+        self.mime
+    }
+
     /// Returns the size of the thumbnail as width,  height
     pub fn size(&self) -> (u32, u32) {
         self.inner.dimensions()
@@ -108,7 +114,7 @@ pub fn create_thumbnails_samplefilter<R: BufRead + Seek, I: IntoIterator<Item = 
     let sizes: Vec<ThumbnailSize> = sizes.into_iter().collect();
     let thumbnails = resize_images(image, &sizes, filter)
         .into_iter()
-        .map(|image| Thumbnail { inner: image })
+        .map(|image| Thumbnail { inner: image, mime })
         .collect();
 
     Ok(thumbnails)
@@ -125,7 +131,7 @@ pub fn create_thumbnails<R: BufRead + Seek, I: IntoIterator<Item = ThumbnailSize
     let sizes: Vec<ThumbnailSize> = sizes.into_iter().collect();
     let thumbnails = resize_images(image, &sizes, FilterType::Lanczos3)
         .into_iter()
-        .map(|image| Thumbnail { inner: image })
+        .map(|image| Thumbnail { inner: image, mime })
         .collect();
 
     Ok(thumbnails)
@@ -149,7 +155,7 @@ pub fn create_thumbnails_unknown_type<R: BufRead + Seek, I: IntoIterator<Item = 
     let sizes: Vec<ThumbnailSize> = sizes.into_iter().collect();
     let thumbnails = resize_images(image, &sizes, FilterType::Lanczos3)
         .into_iter()
-        .map(|image| Thumbnail { inner: image })
+        .map(|image| Thumbnail { inner: image, mime })
         .collect();
 
     Ok(thumbnails)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,14 @@ impl Thumbnail {
 
         Ok(())
     }
+    /// Writes the bytes of the image in a webp format
+    #[cfg(feature = "webp")]
+    pub fn write_webp<W: Write + Seek>(self, writer: &mut W) -> ThumbResult<()> {
+        let image = DynamicImage::ImageRgba8(self.inner.into_rgba8());
+        image.write_to(writer, ImageFormat::WebP)?;
+
+        Ok(())
+    }
 
     /// Returns the size of the thumbnail as width,  height
     pub fn size(&self) -> (u32, u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,19 +8,18 @@
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use std::io::Cursor;
-//!
+//! use file_format::FileFormat;
 //! let file = File::open("tests/assets/test.png").unwrap();
 //! let reader = BufReader::new(file);
-//! let mut  thumbnails = create_thumbnails(reader, mime::IMAGE_PNG, [ThumbnailSize::Small, ThumbnailSize::Medium]).unwrap();
+//! let mut  thumbnails = create_thumbnails(reader, FileFormat::PortableNetworkGraphics, [ThumbnailSize::Small, ThumbnailSize::Medium]).unwrap();
 //!
 //! let thumbnail = thumbnails.pop().unwrap();
 //! let mut buf = Cursor::new(Vec::new());
 //! thumbnail.write_png(&mut buf).unwrap();
 //! ```
-
 use crate::error::ThumbResult;
+use file_format::FileFormat;
 use image::{DynamicImage, GenericImageView, ImageFormat};
-use mime::Mime;
 use rayon::prelude::*;
 use std::io::{BufRead, Seek, Write};
 
@@ -93,7 +92,7 @@ impl Thumbnail {
 /// the mime describing the contents type
 pub fn create_thumbnails_samplefilter<R: BufRead + Seek, I: IntoIterator<Item = ThumbnailSize>>(
     reader: R,
-    mime: Mime,
+    mime: FileFormat,
     sizes: I,
     filter: FilterType,
 ) -> ThumbResult<Vec<Thumbnail>> {
@@ -111,7 +110,7 @@ pub fn create_thumbnails_samplefilter<R: BufRead + Seek, I: IntoIterator<Item = 
 /// the mime describing the contents type
 pub fn create_thumbnails<R: BufRead + Seek, I: IntoIterator<Item = ThumbnailSize>>(
     reader: R,
-    mime: Mime,
+    mime: FileFormat,
     sizes: I,
 ) -> ThumbResult<Vec<Thumbnail>> {
     let image = get_base_image(reader, mime)?;

--- a/src/utils/ffmpeg_cli.rs
+++ b/src/utils/ffmpeg_cli.rs
@@ -27,6 +27,27 @@ pub fn get_png_frame(video_file: &str, index: usize) -> ThumbResult<Vec<u8>> {
     ])
 }
 
+/// Runs ffmpeg to retrieve a png video frame
+pub fn get_webp_frame(video_file: &str, index: usize) -> ThumbResult<Vec<u8>> {
+    ffmpeg([
+        "-loglevel",
+        "panic",
+        "-i",
+        video_file,
+        "-vf",
+        format!("select=eq(n\\,{index})").as_str(),
+        "-vframes",
+        "1",
+        "-c:v",
+        "webp",
+        "-movflags",
+        "empty_moov",
+        "-f",
+        "image2pipe",
+        "pipe:1",
+    ])
+}
+
 /// Runs ffmpeg with the given args
 fn ffmpeg<I: IntoIterator<Item = S>, S: AsRef<OsStr>>(args: I) -> ThumbResult<Vec<u8>> {
     let child = Command::new(FFMPEG)

--- a/tests/image_reading.rs
+++ b/tests/image_reading.rs
@@ -3,7 +3,7 @@ const JPG_BYTES: &[u8] = include_bytes!("assets/test.jpg");
 const WEBP_BYTES: &[u8] = include_bytes!("assets/test.webp");
 
 use crate::ImageType::{Jpeg, Png, Webp};
-use mime::Mime;
+use file_format::FileFormat;
 use std::io::Cursor;
 use std::str::FromStr;
 use thumbnailer::error::ThumbResult;
@@ -64,16 +64,15 @@ fn create_thumbnail(image_type: ImageType, size: ThumbnailSize) -> ThumbResult<V
     match image_type {
         ImageType::Png => {
             let reader = Cursor::new(PNG_BYTES);
-            create_thumbnails(reader, mime::IMAGE_PNG, [size])
+            create_thumbnails(reader, FileFormat::PortableNetworkGraphics, [size])
         }
         ImageType::Jpeg => {
             let reader = Cursor::new(JPG_BYTES);
-            create_thumbnails(reader, mime::IMAGE_JPEG, [size])
+            create_thumbnails(reader, FileFormat::JointPhotographicExpertsGroup, [size])
         }
         ImageType::Webp => {
             let reader = Cursor::new(WEBP_BYTES);
-            let webp_mime = Mime::from_str("image/webp").unwrap();
-            create_thumbnails(reader, webp_mime, [size])
+            create_thumbnails(reader, FileFormat::Webp, [size])
         }
     }
 }

--- a/tests/image_reading.rs
+++ b/tests/image_reading.rs
@@ -7,7 +7,7 @@ use file_format::FileFormat;
 use std::io::Cursor;
 use std::str::FromStr;
 use thumbnailer::error::ThumbResult;
-use thumbnailer::{create_thumbnails, Thumbnail, ThumbnailSize};
+use thumbnailer::{create_thumbnails, create_thumbnails_unknown_type, Thumbnail, ThumbnailSize};
 
 enum ImageType {
     Png,
@@ -59,6 +59,50 @@ fn it_creates_medium_thumbnails_for_webp() {
 fn it_creates_large_thumbnails_for_webp() {
     create_thumbnail(Webp, ThumbnailSize::Large).unwrap();
 }
+#[test]
+fn it_creates_small_thumbnails_for_png_unknown() {
+    create_thumbnails_unknown(Png, ThumbnailSize::Small).unwrap();
+}
+
+#[test]
+fn it_creates_medium_thumbnails_for_png_unknown() {
+    create_thumbnails_unknown(Png, ThumbnailSize::Medium).unwrap();
+}
+
+#[test]
+fn it_creates_large_thumbnails_for_png_unknown() {
+    create_thumbnails_unknown(Png, ThumbnailSize::Large).unwrap();
+}
+
+#[test]
+fn it_creates_small_thumbnails_for_jpeg_unknown() {
+    create_thumbnails_unknown(Jpeg, ThumbnailSize::Small).unwrap();
+}
+
+#[test]
+fn it_creates_medium_thumbnails_for_jpeg_unknown() {
+    create_thumbnails_unknown(Jpeg, ThumbnailSize::Medium).unwrap();
+}
+
+#[test]
+fn it_creates_large_thumbnails_for_jpeg_unknown() {
+    create_thumbnails_unknown(Jpeg, ThumbnailSize::Large).unwrap();
+}
+
+#[test]
+fn it_creates_small_thumbnails_for_webp_unknown() {
+    create_thumbnails_unknown(Webp, ThumbnailSize::Small).unwrap();
+}
+
+#[test]
+fn it_creates_medium_thumbnails_for_webp_unknown() {
+    create_thumbnails_unknown(Webp, ThumbnailSize::Medium).unwrap();
+}
+
+#[test]
+fn it_creates_large_thumbnails_for_webp_unknown() {
+    create_thumbnails_unknown(Webp, ThumbnailSize::Large).unwrap();
+}
 
 fn create_thumbnail(image_type: ImageType, size: ThumbnailSize) -> ThumbResult<Vec<Thumbnail>> {
     match image_type {
@@ -73,6 +117,25 @@ fn create_thumbnail(image_type: ImageType, size: ThumbnailSize) -> ThumbResult<V
         ImageType::Webp => {
             let reader = Cursor::new(WEBP_BYTES);
             create_thumbnails(reader, FileFormat::Webp, [size])
+        }
+    }
+}
+fn create_thumbnails_unknown(
+    image_type: ImageType,
+    size: ThumbnailSize,
+) -> ThumbResult<Vec<Thumbnail>> {
+    match image_type {
+        ImageType::Png => {
+            let mut reader = Cursor::new(PNG_BYTES);
+            create_thumbnails_unknown_type(reader, [size])
+        }
+        ImageType::Jpeg => {
+            let mut reader = Cursor::new(JPG_BYTES);
+            create_thumbnails_unknown_type(reader, [size])
+        }
+        ImageType::Webp => {
+            let mut reader = Cursor::new(WEBP_BYTES);
+            create_thumbnails_unknown_type(reader, [size])
         }
     }
 }

--- a/tests/image_writing.rs
+++ b/tests/image_writing.rs
@@ -1,4 +1,4 @@
-use mime::Mime;
+use file_format::FileFormat;
 use std::io::Cursor;
 use std::str::FromStr;
 use thumbnailer::error::ThumbResult;
@@ -116,16 +116,25 @@ fn write_thumbnail(
     let thumb = match source_format {
         SourceFormat::Png => {
             let reader = Cursor::new(PNG_BYTES);
-            create_thumbnails(reader, mime::IMAGE_PNG, [ThumbnailSize::Medium]).unwrap()
+            create_thumbnails(
+                reader,
+                FileFormat::PortableNetworkGraphics,
+                [ThumbnailSize::Medium],
+            )
+            .unwrap()
         }
         SourceFormat::Jpeg => {
             let reader = Cursor::new(JPG_BYTES);
-            create_thumbnails(reader, mime::IMAGE_JPEG, [ThumbnailSize::Medium]).unwrap()
+            create_thumbnails(
+                reader,
+                FileFormat::JointPhotographicExpertsGroup,
+                [ThumbnailSize::Medium],
+            )
+            .unwrap()
         }
         SourceFormat::Webp => {
             let reader = Cursor::new(WEBP_BYTES);
-            let webp_mime = Mime::from_str("image/webp").unwrap();
-            create_thumbnails(reader, webp_mime, [ThumbnailSize::Medium]).unwrap()
+            create_thumbnails(reader, FileFormat::Webp, [ThumbnailSize::Medium]).unwrap()
         }
     }
     .pop()
@@ -148,14 +157,19 @@ fn write_thumbnail_samplefilter(
     let thumb = match source_format {
         SourceFormat::Png => {
             let reader = Cursor::new(PNG_BYTES);
-            create_thumbnails_samplefilter(reader, mime::IMAGE_PNG, [ThumbnailSize::Medium], filter)
-                .unwrap()
+            create_thumbnails_samplefilter(
+                reader,
+                FileFormat::PortableNetworkGraphics,
+                [ThumbnailSize::Medium],
+                filter,
+            )
+            .unwrap()
         }
         SourceFormat::Jpeg => {
             let reader = Cursor::new(JPG_BYTES);
             create_thumbnails_samplefilter(
                 reader,
-                mime::IMAGE_JPEG,
+                FileFormat::JointPhotographicExpertsGroup,
                 [ThumbnailSize::Medium],
                 filter,
             )
@@ -163,9 +177,13 @@ fn write_thumbnail_samplefilter(
         }
         SourceFormat::Webp => {
             let reader = Cursor::new(WEBP_BYTES);
-            let webp_mime = Mime::from_str("image/webp").unwrap();
-            create_thumbnails_samplefilter(reader, webp_mime, [ThumbnailSize::Medium], filter)
-                .unwrap()
+            create_thumbnails_samplefilter(
+                reader,
+                FileFormat::Webp,
+                [ThumbnailSize::Medium],
+                filter,
+            )
+            .unwrap()
         }
     }
     .pop()

--- a/tests/video_reading.rs
+++ b/tests/video_reading.rs
@@ -1,6 +1,6 @@
 extern crate core;
 
-use mime::Mime;
+use file_format::FileFormat;
 use std::io::Cursor;
 use std::str::FromStr;
 use thumbnailer::error::ThumbError;
@@ -13,7 +13,7 @@ fn it_creates_thumbnails_for_mp4() {
     let reader = Cursor::new(VIDEO_BYTES);
     let result = create_thumbnails(
         reader,
-        Mime::from_str("video/mp4").unwrap(),
+        FileFormat::Mpeg4Part14Video,
         [
             ThumbnailSize::Small,
             ThumbnailSize::Medium,


### PR DESCRIPTION
Changes over to standard FileFormat crate to change over to filetypes. 
Adds support to rip out multiple frames from a video to make an animated thumbnail. 
You don't have to merge this I've just been using this internally for making small animated webps